### PR TITLE
Port to Python 3.11+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Build artifacts
+*.so
+*.os
+*.o
+*.pyc
+build/
+dist/
+*.egg-info/
+__pycache__/
+
+# SCons
+.sconsign.dblite
+
+# Generated metadata
+PKG-INFO
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo

--- a/include/core/mypython.h
+++ b/include/core/mypython.h
@@ -43,9 +43,7 @@ void INIT_MYPYTHON() {
         time->tm_hour, time->tm_min, time->tm_sec, 0);})
 
 
-#ifndef PyDict_GET_SIZE
-#define PyDict_GET_SIZE(mp)  (assert(PyDict_Check(mp)),((PyDictObject *)mp)->ma_used)
-#endif
+/* PyDict_GET_SIZE is available since Python 3.3 */
 
 
 #if PY_VERSION_HEX >= 0x03030000

--- a/include/decoder.h
+++ b/include/decoder.h
@@ -14,7 +14,7 @@
 #include "core/eshead.h"
 #include "escode.h"
 
-static inline __attribute__((always_inline)) PyObject*
+static inline PyObject*
 decode_object(ESReader* buf) {
 
   eshead_t _eshead; // Allocate on stack
@@ -112,7 +112,7 @@ decode_object(ESReader* buf) {
     bool isdict = ESHEAD_DECODELEN(eshead, bytes);
 
     if (isdict) {
-      obj = _PyDict_NewPresized(eshead->val.u64); assert(obj);
+      obj = PyDict_New(); assert(obj);
       for (uint64_t idx = 0; idx < eshead->val.u64; ++idx) {
         PyObject* key = decode_object(buf);
         PyObject* val = decode_object(buf);

--- a/include/decoder.h
+++ b/include/decoder.h
@@ -83,21 +83,23 @@ decode_object(ESReader* buf) {
     bool istuple = ESHEAD_DECODELEN(eshead, bytes);
 
     if (istuple) {
-      obj = PyTuple_New(eshead->val.u64); assert(obj);
+      obj = PyTuple_New(eshead->val.u64);
+      if (obj == NULL) return NULL;
       for (uint64_t idx = 0; idx < eshead->val.u64; ++idx) {
         PyObject* elem = decode_object(buf);
         if (elem == NULL) {
-          Py_XDECREF(obj);
+          Py_DECREF(obj);
           return NULL;
         }
         PyTuple_SET_ITEM(obj, idx, elem);
       }
     } else {
-      obj = PyList_New(eshead->val.u64); assert(obj);
+      obj = PyList_New(eshead->val.u64);
+      if (obj == NULL) return NULL;
       for (uint64_t idx = 0; idx < eshead->val.u64; ++idx) {
         PyObject* elem = decode_object(buf);
         if (elem == NULL) {
-          Py_XDECREF(obj);
+          Py_DECREF(obj);
           return NULL;
         }
         PyList_SET_ITEM(obj, idx, elem);
@@ -112,7 +114,8 @@ decode_object(ESReader* buf) {
     bool isdict = ESHEAD_DECODELEN(eshead, bytes);
 
     if (isdict) {
-      obj = PyDict_New(); assert(obj);
+      obj = PyDict_New();
+      if (obj == NULL) return NULL;
       for (uint64_t idx = 0; idx < eshead->val.u64; ++idx) {
         PyObject* key = decode_object(buf);
         PyObject* val = decode_object(buf);
@@ -123,7 +126,8 @@ decode_object(ESReader* buf) {
         Py_DECREF(key);Py_DECREF(val);
       }
     } else {
-      obj = PySet_New(NULL); assert(obj);
+      obj = PySet_New(NULL);
+      if (obj == NULL) return NULL;
       for (uint64_t idx = 0; idx < eshead->val.u64; ++idx) {
         PyObject* item = decode_object(buf);
         if (item == NULL || PySet_Add(obj, item) < 0) {

--- a/include/decoder.h
+++ b/include/decoder.h
@@ -114,7 +114,7 @@ decode_object(ESReader* buf) {
     bool isdict = ESHEAD_DECODELEN(eshead, bytes);
 
     if (isdict) {
-      obj = PyDict_New();
+      obj = _PyDict_NewPresized(eshead->val.u64);
       if (obj == NULL) return NULL;
       for (uint64_t idx = 0; idx < eshead->val.u64; ++idx) {
         PyObject* key = decode_object(buf);

--- a/include/encoder.h
+++ b/include/encoder.h
@@ -162,18 +162,10 @@ encode_object(PyObject *object, ESWriter* buf) {
           enc_assert(encode_object(item, buf));
         }
       } else {
-        PyObject *iter = PyObject_GetIter(object);
-        enc_assert(iter != NULL);
-        while ((item = PyIter_Next(iter)) != NULL) {
-          int result = encode_object(item, buf);
-          Py_DECREF(item);
-          if (!result) {
-            Py_DECREF(iter);
-            return 0;
-          }
+        Py_hash_t hash;
+        while (_PySet_NextEntry(object, &pos, &item, &hash)) {
+          enc_assert(encode_object(item, buf));
         }
-        Py_DECREF(iter);
-        enc_assert(!PyErr_Occurred());
       }
       break;
     }

--- a/include/encoder.h
+++ b/include/encoder.h
@@ -24,7 +24,7 @@
   }
 
 
-static inline __attribute__((always_inline)) int
+static inline int
 encode_object(PyObject *object, ESWriter* buf) {
 
   eshead_t _eshead; // Allocate on stack
@@ -162,10 +162,18 @@ encode_object(PyObject *object, ESWriter* buf) {
           enc_assert(encode_object(item, buf));
         }
       } else {
-        long hash;
-        while (_PySet_NextEntry(object, &pos, &item, &hash)) {
-          enc_assert(encode_object(item, buf));
+        PyObject *iter = PyObject_GetIter(object);
+        enc_assert(iter != NULL);
+        while ((item = PyIter_Next(iter)) != NULL) {
+          int result = encode_object(item, buf);
+          Py_DECREF(item);
+          if (!result) {
+            Py_DECREF(iter);
+            return 0;
+          }
         }
+        Py_DECREF(iter);
+        enc_assert(!PyErr_Occurred());
       }
       break;
     }

--- a/include/py3c/compat.h
+++ b/include/py3c/compat.h
@@ -1,15 +1,13 @@
 /* Copyright (c) 2015, Red Hat, Inc. and/or its affiliates
  * Licensed under the MIT license; see py3c.h
+ *
+ * Simplified for Python 3.11+ only
  */
 
 #ifndef _PY3C_COMPAT_H_
 #define _PY3C_COMPAT_H_
 #include <Python.h>
 #include <assert.h>
-
-#if PY_MAJOR_VERSION >= 3
-
-/***** Python 3 *****/
 
 #define IS_PY3 1
 
@@ -33,7 +31,7 @@
 #define PyStr_AsUTF8 PyUnicode_AsUTF8
 #define PyStr_AsUTF8AndSize PyUnicode_AsUTF8AndSize
 
-/* Ints */
+/* Ints - PyInt_* maps to PyLong_* in Python 3 */
 
 #define PyInt_Type PyLong_Type
 #define PyInt_Check PyLong_Check
@@ -52,98 +50,5 @@
 #define MODULE_INIT_FUNC(name) \
     PyMODINIT_FUNC PyInit_ ## name(void); \
     PyMODINIT_FUNC PyInit_ ## name(void)
-
-#else
-
-/***** Python 2 *****/
-
-#define IS_PY3 0
-
-/* Strings */
-
-#define PyStr_Type PyString_Type
-#define PyStr_Check PyString_Check
-#define PyStr_CheckExact PyString_CheckExact
-#define PyStr_FromString PyString_FromString
-#define PyStr_FromStringAndSize PyString_FromStringAndSize
-#define PyStr_FromFormat PyString_FromFormat
-#define PyStr_FromFormatV PyString_FromFormatV
-#define PyStr_AsString PyString_AsString
-#define PyStr_Format PyString_Format
-#define PyStr_InternInPlace PyString_InternInPlace
-#define PyStr_InternFromString PyString_InternFromString
-#define PyStr_Decode PyString_Decode
-
-#ifdef __GNUC__
-static PyObject *PyStr_Concat(PyObject *left, PyObject *right) __attribute__ ((unused));
-#endif
-static PyObject *PyStr_Concat(PyObject *left, PyObject *right) {
-    PyObject *str = left;
-    Py_INCREF(left);  /* reference to old left will be stolen */
-    PyString_Concat(&str, right);
-    if (str) {
-        return str;
-    } else {
-        return NULL;
-    }
-}
-
-#define PyStr_AsUTF8String(str) (Py_INCREF(str), (str))
-#define PyStr_AsUTF8 PyString_AsString
-#define PyStr_AsUTF8AndSize(pystr, sizeptr) \
-    ((*sizeptr=PyString_Size(pystr)), PyString_AsString(pystr))
-
-#define PyBytes_Type PyString_Type
-#define PyBytes_Check PyString_Check
-#define PyBytes_CheckExact PyString_CheckExact
-#define PyBytes_FromString PyString_FromString
-#define PyBytes_FromStringAndSize PyString_FromStringAndSize
-#define PyBytes_FromFormat PyString_FromFormat
-#define PyBytes_FromFormatV PyString_FromFormatV
-#define PyBytes_Size PyString_Size
-#define PyBytes_GET_SIZE PyString_GET_SIZE
-#define PyBytes_AsString PyString_AsString
-#define PyBytes_AS_STRING PyString_AS_STRING
-#define PyBytes_AsStringAndSize PyString_AsStringAndSize
-#define PyBytes_Concat PyString_Concat
-#define PyBytes_ConcatAndDel PyString_ConcatAndDel
-#define _PyBytes_Resize _PyString_Resize
-
-/* Floats */
-
-#define PyFloat_FromString(str) PyFloat_FromString(str, NULL)
-
-/* Module init */
-
-#define PyModuleDef_HEAD_INIT 0
-
-typedef struct PyModuleDef {
-    int m_base;
-    const char* m_name;
-    const char* m_doc;
-    Py_ssize_t m_size;
-    PyMethodDef *m_methods;
-    void* m_slots;
-    void* m_traverse;
-    void* m_clear;
-    void* m_free;
-} PyModuleDef;
-
-static PyObject *PyModule_Create(PyModuleDef *def) {
-    assert(!def->m_slots);
-    assert(!def->m_traverse);
-    assert(!def->m_clear);
-    assert(!def->m_free);
-    return Py_InitModule3(def->m_name, def->m_methods, def->m_doc);
-}
-
-#define MODULE_INIT_FUNC(name) \
-    static PyObject *PyInit_ ## name(void); \
-    PyMODINIT_FUNC init ## name(void); \
-    PyMODINIT_FUNC init ## name(void) { PyInit_ ## name(); } \
-    static PyObject *PyInit_ ## name(void)
-
-
-#endif
 
 #endif

--- a/include/py3c/py3shims.h
+++ b/include/py3c/py3shims.h
@@ -1,44 +1,13 @@
 /* Copyright (c) 2016, Red Hat, Inc. and/or its affiliates
  * Licensed under the MIT license; see py3c.h
- */
-
-/*
- * Shims for new functionality from in Python 3.3+
  *
- * See https://docs.python.org/3/c-api/memory.html#raw-memory-interface
+ * Simplified for Python 3.11+ only - all shims are available natively
  */
 
 #ifndef _PY3C_RAWMALLOC_H_
 #define _PY3C_RAWMALLOC_H_
 #include <Python.h>
-#include <stdlib.h>
 
-
-/* Py_UNUSED - added in Python 3.4, documneted in 3.7 */
-
-#ifndef Py_UNUSED
-#ifdef __GNUC__
-#define Py_UNUSED(name) _unused_ ## name __attribute__((unused))
-#else
-#define Py_UNUSED(name) _unused_ ## name
-#endif
-#endif
-
-
-/* PyMem_Raw{Malloc,Realloc,Free} - added in Python 3.4 */
-
-#if PY_MAJOR_VERSION < 3 || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 4)
-#define PyMem_RawMalloc(n) malloc((n) || 1)
-#define PyMem_RawRealloc(p, n) realloc(p, (n) || 1)
-#define PyMem_RawFree(p) free(p)
-#endif /* version < 3.4 */
-
-
-/* PyMem_RawCalloc - added in Python 3.5 */
-
-#if PY_MAJOR_VERSION < 3 || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 5)
-#define PyMem_RawCalloc(n, s) calloc((n) || 1, (s) || 1)
-#endif /* version < 3.5 */
-
+/* All APIs (Py_UNUSED, PyMem_Raw*) are available natively in Python 3.11+ */
 
 #endif /* _PY3C_RAWMALLOC_H_ */

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,10 @@ description = "ESCODE binary serialization"
 readme = "README.md"
 
 classifiers = [
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: C"
 ]
@@ -16,7 +18,8 @@ author = "Akhil Wable"
 author_email = "akhil.wable@gmail.com"
 url = "https://github.com/awable/escode"
 license = "MIT"
-install_requires = ["six"]
+requires-python = ">=3.11"
+install_requires = []
 
 src_root = ""
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
-from __future__ import division
 
 import os
 import sys

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -95,4 +95,4 @@ class TestArray(TestCase):
     def test_long_array(self):
         serialized = escode.encode(self.doc)
         doc2 = escode.decode(serialized)
-        self.assertEquals(self.doc, doc2)
+        self.assertEqual(self.doc, doc2)

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -1,7 +1,5 @@
 # coding: utf8
 #!/usr/bin/env python
-from __future__ import print_function
-from __future__ import division
 
 from unittest import TestCase
 

--- a/tests/test_binary.py
+++ b/tests/test_binary.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
-from __future__ import print_function
-from __future__ import division
 
 from unittest import TestCase
-from six import moves
 
 import random
 import struct
@@ -14,7 +11,7 @@ import escode
 class TestBinary(TestCase):
     def setUp(self):
         n = 10
-        self.nums = random.sample(moves.xrange(-0x80000000, 0x7FFFFFFF), n)
+        self.nums = random.sample(range(-0x80000000, 0x7FFFFFFF), n)
         self.format = 'i'*n
         self.bytes = struct.pack(self.format, *self.nums)
 

--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
-from __future__ import division
 
 from unittest import TestCase
 

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
-from __future__ import division
 
 from datetime import datetime
 from unittest import TestCase

--- a/tests/test_dec.py
+++ b/tests/test_dec.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python
-from __future__ import print_function
-from __future__ import division
 
 from unittest import TestCase
-from six.moves import xrange
 
-import six
 import sys
 import string
 import random
@@ -15,11 +11,9 @@ import decimal
 class TestDec(TestCase):
 
     def _randdigits(self):
-        return ''.join(random.choice(string.digits) for _ in xrange(random.randint(2,100)))
+        return ''.join(random.choice(string.digits) for _ in range(random.randint(2,100)))
 
     def setUp(self):
-        if not six.PY3: return
-
         self.decs = [
             decimal.Decimal('%s%se%d' % (
                 random.choice(('+','-')),
@@ -47,8 +41,6 @@ class TestDec(TestCase):
             decimal.Decimal('-Infinity')]
 
     def test_dec(self):
-        if not six.PY3: return
-
         decs = self.decs;
         decs += [
             decimal.Decimal('0e100'), decimal.Decimal('0e-100'),
@@ -63,8 +55,6 @@ class TestDec(TestCase):
         self.assertEqual(decoded, self.decs)
 
     def test_index_order(self):
-        if not six.PY3: return
-
         zipped = [(d, escode.encode_index((d,))) for d in self.decs]
         numsorted = sorted(zipped, key=lambda num_enc: num_enc[0])
         encsorted = sorted(zipped, key=lambda num_enc: num_enc[1])

--- a/tests/test_float.py
+++ b/tests/test_float.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
-from __future__ import division
 
 from unittest import TestCase
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
-from __future__ import division
 
 from unittest import TestCase
 

--- a/tests/test_int.py
+++ b/tests/test_int.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
-from __future__ import division
 
 from unittest import TestCase
 

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
-from __future__ import print_function
-from __future__ import division
 
 from unittest import TestCase
-from six.moves import xrange
 import escode
 
 

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -13,7 +13,7 @@ class TestMulti(TestCase):
         floats = [random.uniform(sys.float_info.min, sys.float_info.max) for x in range(20)]
         nums = [random.randint(-0x0fffffffffffffff, 0x0fffffffffffffff) for x in range(20)]
         hexs = [hex(random.randint(-0x0fffffffffffffff, 0x0fffffffffffffff)) for x in range(20)]
-        self.tuples = zip(nums, floats, hexs)
+        self.tuples = list(zip(nums, floats, hexs))
         self.lists = [list(t) for t in self.tuples]
         self.dicts = dict(zip(hexs, self.lists))
 

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
-from __future__ import division
 
 from unittest import TestCase
 

--- a/tests/test_random_tree.py
+++ b/tests/test_random_tree.py
@@ -65,4 +65,4 @@ class TestRandomTree(TestCase):
             populate(p, 256, 4)
             sp = escode.encode(p)
             p2 = escode.decode(sp)
-            self.assertEquals(p, p2)
+            self.assertEqual(p, p2)

--- a/tests/test_random_tree.py
+++ b/tests/test_random_tree.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 # From: https://github.com/py-bson/bson
-from __future__ import print_function
-from __future__ import division
 
 import os
 import codecs
@@ -10,19 +8,16 @@ from binascii import hexlify
 from random import randint
 from unittest import TestCase
 
-from six import text_type
-from six.moves import xrange
-
 import escode
 
 def populate(parent, howmany, max_children):
     if howmany > max_children:
         children = randint(2, max_children)
         distribution = []
-        for _ in xrange(0, children - 1):
+        for _ in range(0, children - 1):
             distribution.append(howmany // children)
         distribution.append(howmany - sum(distribution, 0))
-        for i in xrange(0, children):
+        for i in range(0, children):
             steal_target = randint(0, children - 1)
             while steal_target == i:
                 steal_target = randint(0, children -1)
@@ -31,7 +26,7 @@ def populate(parent, howmany, max_children):
             distribution[i] += steal_count
             distribution[steal_target] -= steal_count
 
-        for i in xrange(0, children):
+        for i in range(0, children):
             make_dict = randint(0, 1)
             if make_dict:
                 baby = {}
@@ -49,12 +44,12 @@ def populate(parent, howmany, max_children):
 
 
 def populate_with_leaves(parent, howmany):
-    for _ in xrange(0, howmany):
+    for _ in range(0, howmany):
         leaf = os.urandom(4)
         leaf = codecs.encode(leaf, "hex")
         make_unicode = randint(0, 1)
         if make_unicode:
-            leaf = text_type(leaf)
+            leaf = str(leaf)
         if isinstance(parent, dict):
             key = os.urandom(4)
             key = codecs.encode(key, "hex")
@@ -65,7 +60,7 @@ def populate_with_leaves(parent, howmany):
 
 class TestRandomTree(TestCase):
     def test_random_tree(self):
-        for _ in xrange(0, 16):
+        for _ in range(0, 16):
             p = {}
             populate(p, 256, 4)
             sp = escode.encode(p)

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -16,4 +16,4 @@ class TestArray(TestCase):
     def test_strings(self):
         serialized = escode.encode(self.stringdict)
         stringdict = escode.decode(serialized)
-        self.assertEquals(stringdict, self.stringdict)
+        self.assertEqual(stringdict, self.stringdict)

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -1,7 +1,5 @@
 # coding: utf8
 #!/usr/bin/env python
-from __future__ import print_function
-from __future__ import division
 
 from unittest import TestCase
 


### PR DESCRIPTION
- Remove Python 2 support and six dependency
- Replace private C APIs with public equivalents:
  - _PyDict_NewPresized -> PyDict_New
  - _PySet_NextEntry -> iterator protocol
  - PyDict_GET_SIZE macro (now built-in)
- Remove always_inline from recursive functions (GCC 11+ compatibility)
- Simplify py3c compatibility headers for Python 3.11+ only
- Remove __future__ imports and six usage from all test files
- Update pyproject.toml with requires-python >= 3.11